### PR TITLE
fix: resolve server components render error with advanced clerk changes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,11 +7,14 @@ const isPublicRoute = createRouteMatcher([
   '/login/sso-callback(.*)', // Add SSO callback for login
   '/register',
   '/register/sso-callback(.*)', // Add SSO callback for register
+  '/sso-callback(.*)', // Added generic SSO callback
   '/api/webhooks/clerk',
   '/api/webhooks/stripe',
   '/forgot-password(.*)', // Added forgot-password as public
   '/terms(.*)', // Added terms as public
   '/privacy(.*)', // Added privacy as public
+  '/api/oauth_callback', // Added OAuth callback
+  '/oauth_callback' // Added OAuth callback without API prefix
 ]);
 
 export default clerkMiddleware(async (auth, req: NextRequest) => {


### PR DESCRIPTION
- Update Clerk middleware to allow OAuth and SSO callback paths
- Implement dynamic import of TermsAgreement to prevent SSR issues
- Add robust client-side only mounting for localStorage access
- Improve auth guard redirect handling to prevent server errors
- Use client-side only hooks to prevent server-side localStorage access
- Add improved state synchronization in the terms agreement component

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the list of public routes to include additional SSO and OAuth callback endpoints, as well as forgot-password, terms, and privacy pages.

- **Bug Fixes**
	- Improved client-side rendering and routing behavior in authentication flows to prevent hydration mismatches and premature redirects.
	- Enhanced the Terms Agreement flow to avoid server-side errors and ensure consistent modal state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->